### PR TITLE
Stats responsiveness 

### DIFF
--- a/src/components/home/Stat.js
+++ b/src/components/home/Stat.js
@@ -5,14 +5,14 @@ import React from "react";
 const Stat = ({ icon, stat, type }) => {
   return (
     <div
-      className={`flex flex-row w-11/12 h-full items-center rounded-full border-8 border-winc-yellow ring-8 ring-winc-orange mx-4 text-winc-pink bg-winc-white py-3`}
+      className={`flex flex-row w-11/12 h-full items-center rounded-full border-8 border-winc-yellow ring-8 ring-winc-orange m-4 text-winc-pink bg-winc-white py-3`}
     >
-      <div className="ml-6 mr-0 w-1/12">{icon}</div>
-      <div className="flex flex-col justify-center w-8/12">
-        <div className=" text-center text-3xl sm:text-6xl font-bold sm:text-left">
+      <div className="ml-6 mr-0 w-2/12">{icon}</div>
+      <div className="flex flex-col justify-center w-10/12">
+        <div className=" text-center md:text-6xl text-5xl font-bold sm:text-left">
           {stat}
         </div>
-        <div className=" text-winc-black text-xl sm:text-2xl font-normal text-center sm:text-left">
+        <div className=" text-winc-black text-xl md:text-2xl font-normal text-center">
           {type}
         </div>
       </div>

--- a/src/components/home/Stat.js
+++ b/src/components/home/Stat.js
@@ -5,12 +5,14 @@ import React from "react";
 const Stat = ({ icon, stat, type }) => {
   return (
     <div
-      className={`flex flex-row w-full h-full items-center rounded-full border-8 border-winc-yellow ring-8 ring-winc-orange mx-4 text-winc-pink bg-winc-white py-3 sm: flex flex-row`}
+      className={`flex flex-row w-11/12 h-full items-center rounded-full border-8 border-winc-yellow ring-8 ring-winc-orange mx-4 text-winc-pink bg-winc-white py-3`}
     >
-      <div className="ml-6 mr-0 w-5/12 ">{icon}</div>
+      <div className="ml-6 mr-0 w-1/12">{icon}</div>
       <div className="flex flex-col justify-center w-8/12">
-        <div className=" text-left text-lg sm:text-6xl font-bold">{stat}</div>
-        <div className=" text-winc-black text-lg sm: text-2xl font-normal text-left">
+        <div className=" text-center text-3xl sm:text-6xl font-bold sm:text-left">
+          {stat}
+        </div>
+        <div className=" text-winc-black text-xl sm:text-2xl font-normal text-center sm:text-left">
           {type}
         </div>
       </div>

--- a/src/components/home/Stat.js
+++ b/src/components/home/Stat.js
@@ -1,15 +1,16 @@
 "use client";
 import React from "react";
+
 // style the component here
 const Stat = ({ icon, stat, type }) => {
   return (
     <div
-      className={`flex flex-row w-full h-full items-center rounded-full border-8 border-winc-yellow ring-8 ring-winc-orange mx-4 text-winc-pink bg-winc-white py-3`}
+      className={`flex flex-row w-full h-full items-center rounded-full border-8 border-winc-yellow ring-8 ring-winc-orange mx-4 text-winc-pink bg-winc-white py-3 sm: flex flex-row`}
     >
-      <div className=" w-5/12 ml-6">{icon}</div>
+      <div className="ml-6 mr-0 w-5/12 ">{icon}</div>
       <div className="flex flex-col justify-center w-8/12">
-        <div className=" text-6xl font-bold">{stat}</div>
-        <div className="text-winc-black text-2xl font-normal text-left">
+        <div className=" text-left text-lg sm:text-6xl font-bold">{stat}</div>
+        <div className=" text-winc-black text-lg sm: text-2xl font-normal text-left">
           {type}
         </div>
       </div>

--- a/src/components/home/Stats.js
+++ b/src/components/home/Stats.js
@@ -12,7 +12,7 @@ import Stat from "./Stat";
 
 const Stats = () => {
   return (
-    <div className="flex justify-center items-center bg-winc-pink w-full p-16 outline outline-8 outline-winc-pink outline-offset-8 my-4">
+    <div className="flex justify-center items-center bg-winc-pink p-16 outline outline-8 outline-winc-pink outline-offset-8 my-4">
       <div className=""></div>
       {/* <div className="bg-winc-pink flex flex-row w-11/12"> */}
       <Row className="flex justify-center w-11/12 ">

--- a/src/components/home/Stats.js
+++ b/src/components/home/Stats.js
@@ -3,6 +3,8 @@ import React from "react";
 import { FaChalkboardTeacher } from "react-icons/fa";
 import { IoPersonSharp } from "react-icons/io5";
 import { FaUserGraduate } from "react-icons/fa";
+import { Row } from "react-bootstrap";
+import { Col } from "react-bootstrap";
 
 import Stat from "./Stat";
 
@@ -12,19 +14,32 @@ const Stats = () => {
   return (
     <div className="flex justify-center items-center bg-winc-pink w-full p-16 outline outline-8 outline-winc-pink outline-offset-8 my-4">
       <div className=""></div>
-      <div className="bg-winc-pink flex flex-row w-11/12">
-        <Stat
-          icon={<FaChalkboardTeacher size="84px" />}
-          stat="100+"
-          type="Workshops"
-        />
-        <Stat icon={<IoPersonSharp size="70px" />} stat="500+" type="Members" />
-        <Stat
-          icon={<FaUserGraduate size="70px" />}
-          stat="1000+"
-          type="Alumni"
-        />
-      </div>
+      {/* <div className="bg-winc-pink flex flex-row w-11/12"> */}
+      <Row className="flex justify-center w-11/12 ">
+        <Col className="flex flex-col items-center justify-center text-center mb-12">
+          <Stat
+            icon={<FaChalkboardTeacher size="84px" />}
+            stat="100+"
+            type="Workshops"
+          />
+        </Col>
+        <Col className="flex flex-col items-center justify-center text-center mb-12">
+          <Stat
+            icon={<IoPersonSharp size="70px" />}
+            stat="500+"
+            type="Members"
+          />
+        </Col>
+        <Col className="flex flex-col items-center justify-center text-center mb-12">
+          <Stat
+            icon={<FaUserGraduate size="70px" />}
+            stat="1000+"
+            type="Alumni"
+          />
+        </Col>
+      </Row>
+
+      {/* </div> */}
     </div>
   );
 };

--- a/src/components/home/Stats.js
+++ b/src/components/home/Stats.js
@@ -12,34 +12,42 @@ import Stat from "./Stat";
 
 const Stats = () => {
   return (
-    <div className="flex justify-center items-center bg-winc-pink p-16 outline outline-8 outline-winc-pink outline-offset-8 my-4">
-      <div className=""></div>
-      {/* <div className="bg-winc-pink flex flex-row w-11/12"> */}
-      <Row className="flex justify-center w-11/12 ">
-        <Col className="flex flex-col items-center justify-center text-center mb-12">
+    <div className="flex flex-col justify-center items-center bg-winc-pink outline outline-8 outline-winc-pink outline-offset-8 mb-16">
+      <Row className="flex justify-center w-11/12 h-full my-16">
+        <Col
+          sm={6}
+          md={4}
+          className="flex flex-col items-center justify-center text-center"
+        >
           <Stat
-            icon={<FaChalkboardTeacher size="84px" />}
+            icon={<FaChalkboardTeacher className="text-5xl md:text-8xl" />}
             stat="100+"
             type="Workshops"
           />
         </Col>
-        <Col className="flex flex-col items-center justify-center text-center mb-12">
+        <Col
+          sm={6}
+          md={4}
+          className="flex flex-col items-center justify-center text-center"
+        >
           <Stat
-            icon={<IoPersonSharp size="70px" />}
+            icon={<IoPersonSharp className="text-5xl md:text-7xl" />}
             stat="500+"
             type="Members"
           />
         </Col>
-        <Col className="flex flex-col items-center justify-center text-center mb-12">
+        <Col
+          sm={6}
+          md={4}
+          className="flex flex-col items-center justify-center text-center"
+        >
           <Stat
-            icon={<FaUserGraduate size="70px" />}
+            icon={<FaUserGraduate className="text-5xl md:text-7xl" />}
             stat="1000+"
             type="Alumni"
           />
         </Col>
       </Row>
-
-      {/* </div> */}
     </div>
   );
 };


### PR DESCRIPTION
stats components are in columns when on mobile, but within stats components the icons remain next to the words

Tries to attack both issues currently assigned to me, but only really takes care of the first one

<img width="250" alt="image" src="https://github.com/acm-ucr/winc-website/assets/107077253/5e9a40a7-7c69-4995-af8a-4dd1a9f92918">
